### PR TITLE
install rake 11.2.2 to satisfy dependency

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,6 +108,7 @@ if [ ! -d /vagrant/code-workout ]; then
 fi
 git pull
 
+
 cd /vagrant/code-workout
 bundle install
 bundle exec rake db:populate
@@ -131,6 +132,9 @@ if [ ! -d /vagrant/OpenDSA-LTI ]; then
   git clone https://github.com/OpenDSA/OpenDSA-LTI.git /vagrant/OpenDSA-LTI
 fi
 git pull
+
+echo installing rake
+sudo gem install rake -v 11.2.2
 
 cd /vagrant/OpenDSA-LTI
 bundle install


### PR DESCRIPTION
The patch will fix the following error:

```
Using rack adapter
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ Could not find rake-11.2.2 in any of the sources
Run `bundle install` to install missing gems.
```