### PR TITLE
Add port mapping for opendsa-lti service in dev docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
     command: ["./scripts/start.sh"]
     expose:
       - 8443
+    ports:
+      - 8443:8443
     depends_on:
       - db
       - proxy


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change explicitly maps port `8443` from the container to the host machine to allow additional dockerized services running in separate docker networks (egp-broker) to communicate with opendsa-lti service.